### PR TITLE
Android 6 backup crash, fixed warnings, readme language corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Last Launcher  [![translate](https://img.shields.io/badge/Translation-Crowdin-green)](https://crowdin.com/project/last-launcher)
 
-Last Launcher is Simple, Minimal, Customizable and One Page Android launcher. It aims to provide fastest and simplest user experience.  
+Last Launcher is a simple, minimal, and customizable one page Android launcher. It aims to provide the fastest and simplest user experience.
 
 [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="50">](https://f-droid.org/packages/io.github.subhamtyagi.lastlauncher/)
 
 ### Short story:
-I always in quest of simple and minimal launcher that is light weight on RAM and easy on Device battery. I fed-up by all Android Launcher that are available on F-DROID and Play store(although some are great). So I started developing this launcher which is small in size and fast and full featured.
+I have been questing for a simple and minimal launcher that is light weight on RAM and easy on Device battery. I became fed up by the Android launchers that are available on F-Droid and Google Play Store, although some are great. So I started developing this launcher which is small in size, fast, and full featured.
 
 ## Features
 * Low Battery and CPU usage.
 * Faster than fastest. :)
-* Always free and open source and no ads.
+* Always free and open source with no ads.
 * Material design.
-* No icon and widgets (~~may be a disadvantage~~).
+* No icons and widgets.
 * Colorful app names.
-* Custom Fonts selection.
+* Custom Font selection.
 
 
 ## Contribution and Donation
-1. Create a Pull Request. All codes are simple and well commented.
+1. Create a Pull Request. All code is simple and well commented.
 2. Translate this app on [Crowdin](https://crowdin.com/project/last-launcher) in your local language.
 
 ### To do
@@ -26,18 +26,14 @@ I always in quest of simple and minimal launcher that is light weight on RAM and
 * [ ] Background colors.
 
 ## Screenshots
-| Home|Home|Home|Home|
-|:-:|:-:|:-:|:-:|
-| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/1.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/2.jpg?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/3.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/4.png?raw=true )|
+![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/1.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/2.jpg?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/3.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/4.png?raw=true )|
 
-| Home|Home|Home|Home|
-|:-:|:-:|:-:|:-:|
-| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/5.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/6.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/7.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/8.png?raw=true )|
+![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/5.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/6.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/7.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/8.png?raw=true )|
 
 ## 3rd party Library and font.
 * ### Android Libraries
-  * [android-flowlayout](https://github.com/ApmeM/android-flowlayout)  by [Artem.Votincev](https://github.com/ApmeM), License [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0)
-  * [ColorSeekBar](https://github.com/rtugeek/ColorSeekBar) by  [Jack Fu](https://github.com/rtugeek), License [WTFPL](http://www.wtfpl.net/)
+  * [android-flowlayout](https://github.com/ApmeM/android-flowlayout) by [Artem.Votincev](https://github.com/ApmeM), License [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0)
+  * [ColorSeekBar](https://github.com/rtugeek/ColorSeekBar) by [Jack Fu](https://github.com/rtugeek), License [WTFPL](http://www.wtfpl.net/)
 * ### Fonts 
   * [Raleway fonts](https://github.com/impallari/Raleway/) License: [SIL Open Font License, Version 1.1]([http://scripts.sil.org/OFL](http://scripts.sil.org/OFL))
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Last Launcher  [![translate](https://img.shields.io/badge/Translation-Crowdin-green)](https://crowdin.com/project/last-launcher)
 
-Last Launcher is a simple, minimal, and customizable one page Android launcher. It aims to provide the fastest and simplest user experience.
+Last Launcher is a simple, minimal, and customizable single page Android launcher. It aims to provide the fastest and simplest user experience.
 
 [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="50">](https://f-droid.org/packages/io.github.subhamtyagi.lastlauncher/)
 
 ### Short story:
-I have been questing for a simple and minimal launcher that is light weight on RAM and easy on Device battery. I became fed up by the Android launchers that are available on F-Droid and Google Play Store, although some are great. So I started developing this launcher which is small in size, fast, and full featured.
+I have been questing for a simple and minimal launcher that is light weight on RAM and easy on device battery. I became fed up by the Android launchers that are available on F-Droid and Google Play Store, although some are great. So I started developing this launcher which is small in size, fast, and full featured.
 
 ## Features
 * Low Battery and CPU usage.
@@ -18,7 +18,7 @@ I have been questing for a simple and minimal launcher that is light weight on R
 
 
 ## Contribution and Donation
-1. Create a Pull Request. All code is simple and well commented.
+1. Create a pull request. All code is simple and well commented.
 2. Translate this app on [Crowdin](https://crowdin.com/project/last-launcher) in your local language.
 
 ### To do
@@ -26,16 +26,20 @@ I have been questing for a simple and minimal launcher that is light weight on R
 * [ ] Background colors.
 
 ## Screenshots
-![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/1.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/2.jpg?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/3.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/4.png?raw=true )|
+| Home|Home|Home|Home|
+|:-:|:-:|:-:|:-:|
+| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/1.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/2.jpg?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/3.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/4.png?raw=true )|
 
-![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/5.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/6.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/7.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/8.png?raw=true )|
+| Home|Home|Home|Home|
+|:-:|:-:|:-:|:-:|
+| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/5.png?raw=true "Home")| ![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/6.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/7.png?raw=true "Home")|![Home](/fastlane/metadata/android/en-US/images/phoneScreenshots/8.png?raw=true )|
 
 ## 3rd party Library and font.
 * ### Android Libraries
   * [android-flowlayout](https://github.com/ApmeM/android-flowlayout) by [Artem.Votincev](https://github.com/ApmeM), License [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0)
   * [ColorSeekBar](https://github.com/rtugeek/ColorSeekBar) by [Jack Fu](https://github.com/rtugeek), License [WTFPL](http://www.wtfpl.net/)
 * ### Fonts 
-  * [Raleway fonts](https://github.com/impallari/Raleway/) License: [SIL Open Font License, Version 1.1]([http://scripts.sil.org/OFL](http://scripts.sil.org/OFL))
+  * [Raleway fonts](https://github.com/impallari/Raleway/) by [Pablo Impallari](https://github.com/impallari) License [SIL Open Font License, Version 1.1](http://scripts.sil.org/OFL)
 
 ## Copyright
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
             minifyEnabled false
             shrinkResources false
             applicationIdSuffix = '.debug'
-            resValue "string", "app_name", "Debug Launcher"
+            resValue "string", "app_name", "Debug Last Launcher"
         }
         release {
             debuggable false

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
@@ -382,7 +382,7 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
 
             int openingCounts = DbUtils.getOpeningCounts(activity);
 
-            int updateTime = 0;
+            int updateTime;
             try {
                 //ApplicationInfo appInfo = pm.getApplicationInfo(packageName, 0);
                 long time = pm.getPackageInfo(packageName, 0).lastUpdateTime;
@@ -1081,7 +1081,7 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
         for (Apps apps : mAppsList) {
             try {
                 TextView textView = apps.getTextView();
-                String s = apps.getActivityName().toString();
+                String s = apps.getActivityName();
                 Integer newColor = colorsAndId.get(s);
                 if (newColor == null) continue;
                 textView.setTextColor(newColor);

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalColorSizeDialog.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalColorSizeDialog.java
@@ -77,7 +77,7 @@ public class GlobalColorSizeDialog extends Dialog {
 
         if (colorDefault != DbUtils.NULL_TEXT_COLOR) {
             colorSeekBar.setColor(colorDefault);
-        } else {
+        //} else {
             //do something
         }
 

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/model/Apps.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/model/Apps.java
@@ -65,7 +65,7 @@ public class Apps {
     private boolean isShortcut;
     // last updated date
 
-    private int updateTime = 0;
+    private int updateTime;
 
     private int recentUsedWeight;
 

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/utils/SpUtils.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/utils/SpUtils.java
@@ -34,6 +34,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -198,7 +199,7 @@ class SpUtils {
     }
 
     boolean saveSharedPreferencesToFile() {
-        SimpleDateFormat df = new SimpleDateFormat("YYYY_MM_dd_HHSS");
+        SimpleDateFormat df = new SimpleDateFormat("yyyy_MM_dd_HHSS", Locale.getDefault());
         df.format(new Date());
         String date = df.format(new Date());
         boolean res = false;

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/views/colorseekbar/ColorSeekBar.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/views/colorseekbar/ColorSeekBar.java
@@ -442,11 +442,7 @@ public class ColorSeekBar extends View {
      * @return whether MotionEvent is performing on bar or not
      */
     private boolean isOnBar(RectF r, float x, float y) {
-        if (r.left - mThumbRadius < x && x < r.right + mThumbRadius && r.top - mThumbRadius < y && y < r.bottom + mThumbRadius) {
-            return true;
-        } else {
-            return false;
-        }
+        return r.left - mThumbRadius < x && x < r.right + mThumbRadius && r.top - mThumbRadius < y && y < r.bottom + mThumbRadius;
     }
 
     /**

--- a/app/src/main/res/layout/activity_launcher.xml
+++ b/app/src/main/res/layout/activity_launcher.xml
@@ -1,12 +1,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <ScrollView
-        android:id="@+id/main_screen_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">

--- a/app/src/main/res/layout/dialog_padding.xml
+++ b/app/src/main/res/layout/dialog_padding.xml
@@ -25,7 +25,6 @@
 
     <LinearLayout
 
-        android:id="@+id/left"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -91,7 +90,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/top"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -148,7 +146,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/right"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center|center_horizontal|center_vertical"
@@ -205,7 +202,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/bottom"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center|center_horizontal|center_vertical"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-         classpath 'com.android.tools.build:gradle:3.6.3'//342
+         classpath 'com.android.tools.build:gradle:4.0.0'//342
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/flowlayout/layouts/src/main/java/org/apmem/tools/layouts/logic/CommonLogic.java
+++ b/flowlayout/layouts/src/main/java/org/apmem/tools/layouts/logic/CommonLogic.java
@@ -127,9 +127,11 @@ public class CommonLogic {
     public static int findSize(int modeSize, int controlMaxSize, int contentSize) {
         int realControlSize;
         switch (modeSize) {
+            /* duplicate of default
             case View.MeasureSpec.UNSPECIFIED:
                 realControlSize = contentSize;
                 break;
+             */
             case View.MeasureSpec.AT_MOST:
                 realControlSize = Math.min(contentSize, controlMaxSize);
                 break;
@@ -172,7 +174,7 @@ public class CommonLogic {
 
         // if childGravity is still not specified - set default top - left gravity
         if ((childGravity & Gravity.HORIZONTAL_GRAVITY_MASK) == 0) {
-            childGravity |= Gravity.LEFT;
+            childGravity |= Gravity.START;
         }
         if ((childGravity & Gravity.VERTICAL_GRAVITY_MASK) == 0) {
             childGravity |= Gravity.TOP;
@@ -197,8 +199,8 @@ public class CommonLogic {
         if (config.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL && (childGravity & Gravity.RELATIVE_LAYOUT_DIRECTION) != 0) {
             int ltrGravity = childGravity;
             childGravity = 0;
-            childGravity |= (ltrGravity & Gravity.LEFT) == Gravity.LEFT ? Gravity.RIGHT : 0;
-            childGravity |= (ltrGravity & Gravity.RIGHT) == Gravity.RIGHT ? Gravity.LEFT : 0;
+            childGravity |= (ltrGravity & Gravity.START) == Gravity.START ? Gravity.END : 0;
+            childGravity |= (ltrGravity & Gravity.END) == Gravity.END ? Gravity.START : 0;
         }
 
         return childGravity;

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,9 @@
 org.gradle.parallel=true
 #android.enableR8=true
 org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=512m -Dfile.encoding=UTF-8
-
 android.useAndroidX=false
 android.enableJetifier=false
-android.enableR8=true
-android.enableR8.fullMode=true
+#exerimental
+#android.enableR8=true
+#deprecated
+#android.enableR8.fullMode=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 26 12:25:20 IST 2020
+#Sun Jul 05 23:48:41 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
I am in love with Last Launcher, it is wonderful!
I've resolved the issue with backup causing a crash in Android 6, it was because SimpleDateFormat does not work with capital Y in that version, but using lowercase instead solves the problem.
Also, I found a few compiler warnings that were easy enough to correct, and the 'reformat code' and 'code cleanup' options in Android Studio appear to have made some changes.
The readme document has been amended to resemble proper English as best I can.
I hope you consider adding my patches to the official code base, I tested the new build, everything seems to work fine.
Thanks and have a great day!