### PR TITLE
Issue 75- re-enabled app not being shown in launcher

### DIFF
--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
@@ -528,6 +528,7 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
     @Override
     protected void onResume() {
         super.onResume();
+        loadApps();
         if (searching) {
             mSearchBox.setVisibility(View.GONE);
             searching = false;

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,7 +5,6 @@
 
     <string name="color_for_this_entry">Farben &amp; Größe</string>
     <string name="action_settings">Einstellungen</string>
-    <string name="color_for_this_entry">Farben und Größe</string>
     <string name="rename">Umbenenen</string>
     <!--launcher menu-->
     <string name="uninstall">Deinstallieren</string>


### PR DESCRIPTION
This solves the problem with the launcher having an outdated list of shortcuts as mentioned in #75 . However, the leakCanary is still detecting leaks in ShortcutUtils.db.