### PR TITLE
A solution for issue #151

### DIFF
--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
@@ -587,6 +587,14 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
         return true;
     }
 
+    public void addAppSpacing() {
+        mHomeLayout.addletterSpacingRate();
+    }
+
+    public void minusAppSpacint() {
+        mHomeLayout.minusletterSpacingRate();
+    }
+
     private void showPopup(String activityName, AppTextView view) {
 
         Context context;

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalSettingsDialog.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalSettingsDialog.java
@@ -369,6 +369,16 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
 
     }
 
+    private void addAppSpacing() {
+        cancel();
+        launcherActivity.addAppSpacing();
+    }
+
+    private void minuAppSpacing() {
+        cancel();
+        launcherActivity.minusAppSpacint();
+    }
+
     private void fontSelection(View view) {
 
         Context context;
@@ -384,6 +394,14 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
 
         popupMenu.setOnMenuItemClickListener(menuItem -> {
             switch (menuItem.getItemId()) {
+                case R.id.menu_add_spacing:
+                    addAppSpacing();
+                    launcherActivity.loadApps();
+                    break;
+                case R.id.menu_minus_spacing:
+                    minuAppSpacing();
+                    launcherActivity.loadApps();
+                    break;
                 case R.id.menu_choose_fonts:
                     setFonts();
                     break;

--- a/app/src/main/res/menu/font_selection_popup.xml
+++ b/app/src/main/res/menu/font_selection_popup.xml
@@ -25,4 +25,10 @@
     <item
         android:id="@+id/menu_choose_fonts"
         android:title="@string/select_fonts" />
+    <item
+            android:id="@+id/menu_add_spacing"
+            android:title="@string/add_app_spacing" />
+    <item
+            android:id="@+id/menu_minus_spacing"
+            android:title="@string/minus_app_spacing" />
 </menu>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -56,4 +56,6 @@
     <string name="color_for_this_entry">颜色&amp;尺寸</string>
     <string name="action_settings">设置</string>
     <string name="restart_launcher">重启启动器</string>
+    <string name="add_app_spacing">增大应用间距</string>
+    <string name="minus_app_spacing">减小应用间距</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,4 +90,6 @@
     <!--Sort Apps IN : RECENTLY USED FIRST ORDER -->
     <string name="recently_first">Recently first</string>
     <string name="restart_launcher">Restart Launcher</string>
+    <string name="add_app_spacing">Add app spacing</string>
+    <string name="minus_app_spacing">Minus app spacing</string>
 </resources>

--- a/flowlayout/layouts/src/main/java/org/apmem/tools/layouts/FlowLayout.java
+++ b/flowlayout/layouts/src/main/java/org/apmem/tools/layouts/FlowLayout.java
@@ -26,6 +26,18 @@ public class FlowLayout extends ViewGroup {
     List<LineDefinition> lines = new ArrayList<>();
     List<ViewDefinition> views = new ArrayList<>();
 
+    private double letterSpacingRate = 0;
+
+    public void addletterSpacingRate() {
+        letterSpacingRate += 0.1;
+    }
+
+    public void minusletterSpacingRate() {
+        if (letterSpacingRate>0) {
+            letterSpacingRate -= 0.1;
+        }
+    }
+
     public FlowLayout(Context context) {
         super(context);
         this.config = new ConfigDefinition();
@@ -86,7 +98,7 @@ public class FlowLayout extends ViewGroup {
             );
 
             ViewDefinition view = new ViewDefinition(this.config, child);
-            view.setWidth(child.getMeasuredWidth());
+            view.setWidth((int)(child.getMeasuredWidth()*(1+letterSpacingRate)));
             view.setHeight(child.getMeasuredHeight());
             view.setNewLine(lp.isNewLine());
             view.setGravity(lp.getGravity());


### PR DESCRIPTION
When the font is italic, the font of an app may not be fully displayed. I found that I could solve this problem by increasing the width of each view. I added two items. You can then adjust the width of the view.
The Main code is: `view.setWidth((int)(child.getMeasuredWidth()*(1+letterSpacingRate)));`
The specific performance effects are as follows:
When changing the font to be italic:
![a](https://user-images.githubusercontent.com/63643486/169688928-d0749f9c-338e-4b5f-bc7a-b76ecbabc50f.png)
After we add apps spacing:
![b](https://user-images.githubusercontent.com/63643486/169688961-56343f0f-1002-4ede-969d-6ddd3aac555b.png)
![c](https://user-images.githubusercontent.com/63643486/169688973-3fd23a71-eef7-47dd-946b-e15aeb560d91.png)

Users can add apps spacing by themselves to avoid this condition now!~~

addition:
The test font is `Alegreya-Italic.ttf`

