### PR TITLE
fix the bug in theme selection dialog

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -45,7 +45,6 @@
         <item name="android:listPreferredItemHeightSmall">40dp</item>
         <item name="android:listPreferredItemPaddingLeft">5dp</item>
         <item name="android:listPreferredItemPaddingRight">5dp</item>
-        <item name="android:textColor">#FFFFFFFF</item>
         <!--<item name="android:switchTextAppearance">#FFFFff</item>-->
         <item name="android:popupBackground">#FF000000</item>
         <item name="android:popupMenuStyle">@style/PopupMenu</item>


### PR DESCRIPTION
#187 When I choose the hacker green, the text color in wallpaper theme is still white but not hacker green. The same problem happens on other themes especially on white theme which cause the text color is also white. I have fixed this little bug already.