### PR TITLE
Drag apps to order in color sorted view

### DIFF
--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/LauncherActivity.java
@@ -136,7 +136,7 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
 
 
     //region Field declarations
-    public static List<Apps> mAppsList;
+    public final static List<Apps> mAppsList = Collections.synchronizedList(new ArrayList<>());
     // home layout
     private static FlowLayout mHomeLayout;
     // when search bar appears this will be true and show search result
@@ -332,8 +332,6 @@ public class LauncherActivity extends Activity implements View.OnClickListener,
 
         // Log.d(TAG, "loadApps: install shortcut sizes::" + installedShortcut);
         final int appsCount = activities.size();
-
-        mAppsList = Collections.synchronizedList(new ArrayList<>(appsCount + installedShortcut));
 
         // get the most used apps
         // a list of app that are popular on f-droid and some of my apps

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/FrozenAppsDialogs.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/FrozenAppsDialogs.java
@@ -28,6 +28,7 @@ import android.widget.ListView;
 import android.widget.PopupMenu;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import io.github.subhamtyagi.lastlauncher.R;
@@ -94,6 +95,7 @@ public class FrozenAppsDialogs extends Dialog {
                 }
             }
         }
+        Collections.sort(frozenApps, (o1, o2) -> o1.getAppName().compareToIgnoreCase(o2.getAppName()));
         return frozenApps.size();
     }
 

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalSettingsDialog.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/dialogs/GlobalSettingsDialog.java
@@ -57,6 +57,7 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
     private final LauncherActivity launcherActivity;
     private final Context context;
     private TextView freezeSize;
+    private TextView dragApps;
 
     public GlobalSettingsDialog(Context context, LauncherActivity launcherActivity) {
         super(context);
@@ -88,8 +89,10 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
         findViewById(R.id.settings_padding).setOnClickListener(this);
         findViewById(R.id.settings_color_size).setOnClickListener(this);
         findViewById(R.id.settings_sort_app_by).setOnClickListener(this);
-        findViewById(R.id.settings_sort_app_reverse).setOnClickListener(this);
         findViewById(R.id.settings_restart_launcher).setOnClickListener(this);
+
+        dragApps = findViewById(R.id.drag_apps);
+        dragApps.setOnClickListener(this);
 
         //TODO: remove this var
         TextView colorSniffer = findViewById(R.id.settings_color_sniffer);
@@ -105,13 +108,18 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
         findViewById(R.id.settings_frozen_apps).setOnClickListener(this);
         findViewById(R.id.settings_hidden_apps).setOnClickListener(this);
 
-
         //reflect the DB value
         if (DbUtils.isSizeFrozen()) {
             freezeSize.setText(R.string.unfreeze_app_size);
-        } else
+        } else {
             freezeSize.setText(R.string.freeze_apps_size);
+        }
 
+        if (DbUtils.getEnableAppsDragging()) {
+            dragApps.setText(R.string.disable_apps_dragging);
+        } else {
+            dragApps.setText(R.string.enable_apps_dragging);
+        }
     }
 
     @Override
@@ -131,10 +139,6 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
             }
             case R.id.settings_sort_app_by: {
                 sortApps(view);
-                break;
-            }
-            case R.id.settings_sort_app_reverse: {
-                sortAppsReverseOrder();
                 break;
             }
             case R.id.settings_color_size: {
@@ -168,6 +172,9 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
                 break;
             case R.id.settings_restart_launcher:
                 launcherActivity.recreate();
+                break;
+            case R.id.drag_apps:
+                toggleAppsDragging();
                 break;
 
         }
@@ -213,6 +220,9 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
                     break;
                 case R.id.menu_sort_by_recent_use:
                     launcherActivity.sortApps(Constants.SORT_BY_RECENT_OPEN);
+                    break;
+                case R.id.settings_sort_app_reverse:
+                    sortAppsReverseOrder();
                     break;
             }
             return true;
@@ -262,6 +272,17 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
 
     }
 
+    private void toggleAppsDragging() {
+        boolean appsDraggingEnabled = DbUtils.getEnableAppsDragging();
+        DbUtils.setEnableAppsDragging(!appsDraggingEnabled);
+
+        if (!appsDraggingEnabled) {
+            dragApps.setText(R.string.disable_apps_dragging);
+        } else {
+            dragApps.setText(R.string.enable_apps_dragging);
+        }
+    }
+
     private void randomColor() {
         boolean rColor = !DbUtils.isRandomColor();
         DbUtils.randomColor(rColor);
@@ -303,8 +324,9 @@ public class GlobalSettingsDialog extends Dialog implements View.OnClickListener
         DbUtils.freezeSize(!b);
         if (!b) {
             freezeSize.setText(R.string.unfreeze_app_size);
-        } else
+        } else {
             freezeSize.setText(R.string.freeze_apps_size);
+        }
     }
 
     private void frozenApps() {

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/utils/DbUtils.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/utils/DbUtils.java
@@ -62,6 +62,7 @@ public class DbUtils {
     private static final String APPS_COLORS_DEFAULT = "apps_color_default";
     private static final String APPS_SORTS_TYPE = "apps_sorts_types";
     private static final String APPS_SORTS_REVERSE_ORDER = "apps_sorts_reverse_order";
+    private static final String ENABLE_APPS_DRAGGING = "enable_apps_dragging";
 
 
     public static void init(Context context) {
@@ -395,6 +396,14 @@ public class DbUtils {
 
     public static void setAppSortReverseOrder(boolean reverseOrder) {
         SpUtils.getInstance().putBoolean(APPS_SORTS_REVERSE_ORDER, reverseOrder);
+    }
+
+    public static boolean getEnableAppsDragging() {
+        return SpUtils.getInstance().getBoolean(ENABLE_APPS_DRAGGING, false);
+    }
+
+    public static void setEnableAppsDragging(boolean enableAppsDragging) {
+        SpUtils.getInstance().putBoolean(ENABLE_APPS_DRAGGING, enableAppsDragging);
     }
 
     //  a simple ciphered counter: "opening counter" is a private thing

--- a/app/src/main/java/io/github/subhamtyagi/lastlauncher/views/colorseekbar/ColorSeekBar.java
+++ b/app/src/main/java/io/github/subhamtyagi/lastlauncher/views/colorseekbar/ColorSeekBar.java
@@ -500,7 +500,7 @@ public class ColorSeekBar extends View {
     }
 
     /**
-     * Set color,the mCachedColors must contains the specified color, if not ,invoke setColorBarPosition(0);
+     * Set color,the mCachedColors must contains the specified color, if not take the nearest
      *
      * @param color
      */
@@ -508,6 +508,23 @@ public class ColorSeekBar extends View {
         int withoutAlphaColor = Color.rgb(Color.red(color), Color.green(color), Color.blue(color));
         if (mInit) {
             int value = mCachedColors.indexOf(withoutAlphaColor);
+
+            if (value == -1) {
+                float[] hsv = new float[3];
+                Color.colorToHSV(color, hsv);
+
+                float[] cachedHsv = new float[3];
+
+                for (int i = 7; i < mCachedColors.size(); i++) {
+                    Color.colorToHSV(mCachedColors.get(i), cachedHsv);
+
+                    if (cachedHsv[0] < hsv[0]) {
+                        value = i;
+                        break;
+                    }
+                }
+            }
+
             setAlphaValue(Color.alpha(color));
             setColorBarPosition(value);
 

--- a/app/src/main/res/layout/dialog_global_settings.xml
+++ b/app/src/main/res/layout/dialog_global_settings.xml
@@ -155,24 +155,6 @@
             android:foregroundGravity="center_vertical|center_horizontal" />
 
         <TextView
-            android:id="@+id/settings_sort_app_reverse"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:paddingTop="5dp"
-            android:paddingBottom="5dp"
-            android:text="@string/sort_apps_reverse"
-            android:textSize="20sp" />
-
-
-        <View
-            android:layout_width="170dp"
-            android:layout_height="1dp"
-            android:layout_gravity="center|center_horizontal|center_vertical"
-            android:background="#DEDEDE"
-            android:foregroundGravity="center_vertical|center_horizontal" />
-
-        <TextView
             android:id="@+id/settings_freeze_size"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -217,6 +199,24 @@
             android:paddingBottom="5dp"
 
             android:text="@string/frozen_apps"
+            android:textSize="20sp" />
+
+        <View
+            android:layout_width="170dp"
+            android:layout_height="1dp"
+            android:layout_gravity="center|center_horizontal|center_vertical"
+            android:background="#DEDEDE"
+            android:foregroundGravity="center_vertical|center_horizontal" />
+
+        <TextView
+            android:id="@+id/drag_apps"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
+
+            android:text="@string/enable_apps_dragging"
             android:textSize="20sp" />
 
         <View

--- a/app/src/main/res/menu/sort_apps_popups.xml
+++ b/app/src/main/res/menu/sort_apps_popups.xml
@@ -44,4 +44,8 @@
         android:title="@string/recently_first" />
     <!--<item android:id="@+id/menu_sort_by_customs"
         android:title="@string/custom"/>-->
+
+    <item
+        android:id="@+id/settings_sort_app_reverse"
+        android:title="Reverse order" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,6 @@
     <!--Sort Apps IN : RECENTLY USED FIRST ORDER -->
     <string name="recently_first">Recently first</string>
     <string name="restart_launcher">Restart Launcher</string>
+    <string name="enable_apps_dragging">Enable Dragging</string>
+    <string name="disable_apps_dragging">Disable Dragging</string>
 </resources>


### PR DESCRIPTION
 Added feature to drag'n'drop apps in color sorted view. The dropped app gets a color between the 2 apps it was dropped on. This improves the ability to order the apps to your liking in color view massively. It's much easier to drag'n'drop them than to change the color of each app you want to move.